### PR TITLE
docker: run node explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,5 @@ COPY . /app
 WORKDIR /app
 
 RUN yarn install --production
-RUN yarn link
 
-RUN chmod +x /usr/local/bin/payouts
-
-ENTRYPOINT ["/usr/local/bin/payouts"]
+ENTRYPOINT ["node", "/app/build/index.js"]


### PR DESCRIPTION
This fixes an issue where `yarn link` wasn't creating a symlink
properly, and also removes one layer from the final image.

Closes #21